### PR TITLE
Omit mutation object when there are no mutations

### DIFF
--- a/src/main/java/graphql/servlet/GraphQLServlet.java
+++ b/src/main/java/graphql/servlet/GraphQLServlet.java
@@ -68,7 +68,6 @@ public class GraphQLServlet extends HttpServlet implements Servlet, GraphQLMBean
 
     protected void updateSchema() {
         GraphQLObjectType.Builder object = newObject().name("query");
-        GraphQLObjectType.Builder mutationObject = newObject().name("mutation");
 
         for (GraphQLQueryProvider provider : queryProviders) {
             GraphQLObjectType query = provider.getQuery();
@@ -80,12 +79,19 @@ public class GraphQLServlet extends HttpServlet implements Servlet, GraphQLMBean
                     build());
         }
 
-        for (GraphQLMutationProvider provider : mutationProviders) {
-            provider.getMutations().forEach(mutationObject::field);
-        }
-
         readOnlySchema = newSchema().query(object.build()).build();
-        schema = newSchema().query(object.build()).mutation(mutationObject.build()).build();
+
+        if (mutationProviders.isEmpty()) {
+            schema = readOnlySchema;
+        } else {
+            GraphQLObjectType.Builder mutationObject = newObject().name("mutation");
+
+            for (GraphQLMutationProvider provider : mutationProviders) {
+                provider.getMutations().forEach(mutationObject::field);
+            }
+
+            schema = newSchema().query(object.build()).mutation(mutationObject.build()).build();
+        }
     }
 
     public GraphQLServlet() {

--- a/src/test/java/graphql/servlet/GraphQLServletTest.java
+++ b/src/test/java/graphql/servlet/GraphQLServletTest.java
@@ -90,7 +90,7 @@ public class GraphQLServletTest {
         assertTrue(servlet.schema.getMutationType().getFieldDefinition("int").getType().equals(GraphQLInt));
         assertNull(servlet.readOnlySchema.getMutationType());
         servlet.unbindMutationProvider(mutationProvider);
-        assertTrue(servlet.schema.getMutationType().getFieldDefinitions().isEmpty());
+        assertNull(servlet.schema.getMutationType());
     }
 
     @Test @SneakyThrows


### PR DESCRIPTION
graphql-js, which is used by babel-relay-plugin, gives the following when the mutation object is empty:

> Error: mutation fields must be an object with field names as keys or a function which returns such an object.