### PR TITLE
Servlet API downgrade, correction in groupId and made some service references optional

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -65,7 +65,7 @@ publishing {
     publications {
         MyPublication(MavenPublication) {
             from components.java
-            groupId 'graphql-java-servlet'
+            groupId 'com.graphql-java'
             artifactId project.name
             version project.version
 
@@ -112,7 +112,7 @@ dependencies {
     compile 'biz.aQute.bnd:biz.aQute.bndlib:3.1.0'
 
     // Servlet
-    compile 'javax.servlet:javax.servlet-api:3.1.0'
+    compile 'javax.servlet:javax.servlet-api:3.0.1'
     // Multipart support
     compile 'commons-fileupload:commons-fileupload:1.3.1'
 

--- a/src/main/java/graphql/servlet/GraphQLServlet.java
+++ b/src/main/java/graphql/servlet/GraphQLServlet.java
@@ -131,7 +131,7 @@ public class GraphQLServlet extends HttpServlet implements Servlet, GraphQLMBean
     private GraphQLContextBuilder contextBuilder = new DefaultGraphQLContextBuilder();
     private ExecutionStrategyProvider executionStrategyProvider = new EnhancedExecutionStrategyProvider();
 
-    @Reference
+    @Reference(cardinality = ReferenceCardinality.OPTIONAL)
     public void setContextProvider(GraphQLContextBuilder contextBuilder) {
         this.contextBuilder = contextBuilder;
     }
@@ -139,7 +139,7 @@ public class GraphQLServlet extends HttpServlet implements Servlet, GraphQLMBean
         this.contextBuilder = new DefaultGraphQLContextBuilder();
     }
 
-    @Reference
+    @Reference(cardinality = ReferenceCardinality.OPTIONAL)
     public void setExecutionStrategyProvider(ExecutionStrategyProvider provider) {
         executionStrategyProvider = provider;
     }


### PR DESCRIPTION
Hello,

This pull request contains a few changes I made to be able to use this project in our of our products. 
- Quick correction in the build.gradle file where the groupId in MyPublication was still the old one
- Downgraded the Servlet API version from 3.1.0 to 3.0.1 because our application platform only support 3.0 for the time being and I couldn't identify a strong need to use version 3.1 in the servlet (unless I missed something ?)
- Made the service references for the context and execution strategy providers optional as they do have default implementations.

I hope these changes will be useful and may be accepted back into the project. If not please don't hesitate to comment on this PR I will do my best to address any issues or questions.

Best regards,
  Serge Huber.