### PR TITLE
Specification updates

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -117,8 +117,8 @@ dependencies {
     compile 'commons-fileupload:commons-fileupload:1.3.1'
 
     // GraphQL
-    compile 'com.graphql-java:graphql-java:2.0.0'
-    compile 'com.graphql-java:graphql-java-annotations:0.9.0'
+    compile 'com.graphql-java:graphql-java:2.1.0'
+    compile 'com.graphql-java:graphql-java-annotations:0.11.0'
 
     // JSON
     compile 'com.fasterxml.jackson.core:jackson-core:2.7.3'
@@ -155,7 +155,7 @@ extraArchive {
 modifyPom {
      project {
          name 'graphql-java-servlet'
-         description 'elay.js-compatible GraphQL servlet'
+         description 'relay.js-compatible GraphQL servlet'
          url 'https://github.com/graphql-java/graphql-java-servlet'
          inceptionYear '2016'
 


### PR DESCRIPTION
This pull request contains the following modifications and fixes : 
- Update graphql-java to 2.1.0 to get support of directive locations
- Update graphql-java-annotations to 0.11.0
- Fix minor typo in project description
- Modify variables setter to use JSON format instead of string forma as is now documented in the latest specification here : http://graphql.org/learn/serving-over-http/#post-request . This change is also now done on GraphiQL : graphql/graphiql#168
- Add support for GET parameters (query and variables) as is also specified here : http://graphql.org/learn/serving-over-http/#get-request
- Fix some NPEs when no parameters where specified.
All these changes have been tested against the latest master branch of GraphiQL.