### PR TITLE
Added support for initial types dictionnary

### DIFF
--- a/src/main/java/graphql/servlet/GraphQLTypesProvider.java
+++ b/src/main/java/graphql/servlet/GraphQLTypesProvider.java
@@ -1,0 +1,23 @@
+/**
+ * Copyright 2016 Yurii Rashkovskii
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ */
+package graphql.servlet;
+
+import graphql.schema.GraphQLType;
+
+import java.util.Collection;
+
+public interface GraphQLTypesProvider {
+    Collection<GraphQLType> getTypes();
+}


### PR DESCRIPTION
An implementation of GraphQLTypesProvider can provide a list of types, which will be passed to the schema when initializing it. This is particularily useful when using GraphQL Interfaces, as types implementing the interfaces may not appear in the query types tree.