### PR TITLE
Extract common graphql request handling into abstract parent

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .gradle
 build
 *.iml
+.idea/
 *.ipr
 *.iws

--- a/src/main/java/graphql/servlet/AbstractGraphQLServlet.java
+++ b/src/main/java/graphql/servlet/AbstractGraphQLServlet.java
@@ -50,7 +50,7 @@ import java.util.*;
 import java.util.stream.Collectors;
 
 @Slf4j
-public class AbstractGraphQLServlet extends HttpServlet implements Servlet, GraphQLMBean, GraphQLSchemaProvider {
+public abstract class AbstractGraphQLServlet extends HttpServlet implements Servlet, GraphQLMBean, GraphQLSchemaProvider {
 
     AbstractGraphQLServlet() {
         this(new DefaultGraphQLContextBuilder(), new EnhancedExecutionStrategyProvider(), new ArrayList<>());

--- a/src/main/java/graphql/servlet/AbstractGraphQLServlet.java
+++ b/src/main/java/graphql/servlet/AbstractGraphQLServlet.java
@@ -1,0 +1,228 @@
+/**
+ * Copyright 2016 Yurii Rashkovskii
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ */
+package graphql.servlet;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonDeserializer;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.RuntimeJsonMappingException;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.google.common.io.CharStreams;
+import graphql.*;
+import graphql.schema.GraphQLFieldDefinition;
+import graphql.schema.GraphQLSchema;
+import graphql.validation.ValidationError;
+import lombok.Getter;
+import lombok.Setter;
+import lombok.SneakyThrows;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.fileupload.FileItemIterator;
+import org.apache.commons.fileupload.FileItemStream;
+import org.apache.commons.fileupload.FileUploadException;
+import org.apache.commons.fileupload.servlet.ServletFileUpload;
+
+import javax.security.auth.Subject;
+import javax.servlet.Servlet;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.security.AccessController;
+import java.security.PrivilegedAction;
+import java.util.*;
+import java.util.stream.Collectors;
+
+@Slf4j
+public class AbstractGraphQLServlet extends HttpServlet implements Servlet, GraphQLMBean, GraphQLSchemaProvider {
+
+    AbstractGraphQLServlet() {
+        this(new DefaultGraphQLContextBuilder(), new EnhancedExecutionStrategyProvider(), new ArrayList<>());
+    }
+
+    AbstractGraphQLServlet(GraphQLContextBuilder contextBuilder, ExecutionStrategyProvider executionStrategyProvider, List<GraphQLOperationListener> operationListeners) {
+        this.contextBuilder = contextBuilder;
+        this.executionStrategyProvider = executionStrategyProvider;
+        this.operationListeners = operationListeners;
+
+    }
+
+    protected GraphQLContextBuilder contextBuilder;
+    protected ExecutionStrategyProvider executionStrategyProvider;
+    protected List<GraphQLOperationListener> operationListeners;
+
+    @Getter
+    protected GraphQLSchema schema;
+    @Getter
+    protected GraphQLSchema readOnlySchema;
+
+    @Override
+    public String[] getQueries() {
+        return schema.getQueryType().getFieldDefinitions().stream().map(GraphQLFieldDefinition::getName).toArray(String[]::new);
+    }
+
+    @Override
+    public String[] getMutations() {
+        return schema.getMutationType().getFieldDefinitions().stream().map(GraphQLFieldDefinition::getName).toArray(String[]::new);
+    }
+
+    protected GraphQLContext createContext(Optional<HttpServletRequest> req, Optional<HttpServletResponse> resp) {
+        return contextBuilder.build(req, resp);
+    }
+
+    @Override @SneakyThrows
+    public String executeQuery(String query) {
+        try {
+            ExecutionResult result = new GraphQL(schema).execute(query, createContext(Optional.empty(), Optional.empty()), new HashMap<>());
+            if (result.getErrors().isEmpty()) {
+                return new ObjectMapper().writeValueAsString(result.getData());
+            } else {
+                return new ObjectMapper().writeValueAsString(getGraphQLErrors(result));
+            }
+        } catch (Exception e) {
+            return e.getMessage();
+        }
+    }
+
+    @Override
+    protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException {
+        GraphQLContext context = createContext(Optional.of(req), Optional.of(resp));
+        String path = req.getPathInfo();
+        if (path == null) {
+            path = req.getServletPath();
+        }
+        if (path.contentEquals("/schema.json")) {
+            query(CharStreams.toString(new InputStreamReader(GraphQLServlet.class.getResourceAsStream("introspectionQuery"))), null, new HashMap<>(), schema, req, resp, context);
+        } else {
+            if (req.getParameter("q") != null) {
+                query(req.getParameter("q"), null, new HashMap<>(), readOnlySchema, req, resp, context);
+            } else if (req.getParameter("query") != null) {
+                Map<String,Object> variables = new HashMap<>();
+                if (req.getParameter("variables") != null) {
+                    variables.putAll(new ObjectMapper().readValue(req.getParameter("variables"), new TypeReference<Map<String,Object>>() {}));
+                }
+                String operationName = null;
+                if (req.getParameter("operationName") != null) {
+                    operationName = req.getParameter("operationName");
+                }
+                query(req.getParameter("query"), operationName, variables, readOnlySchema, req, resp, context);
+            }
+        }
+    }
+
+    @Override
+    protected void doPost(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException {
+        GraphQLContext context = createContext(Optional.of(req), Optional.of(resp));
+        InputStream inputStream = null;
+        if (ServletFileUpload.isMultipartContent(req)) {
+            ServletFileUpload upload = new ServletFileUpload();
+            try {
+                FileItemIterator it = upload.getItemIterator(req);
+                context.setFiles(Optional.of(it));
+                while (inputStream == null && it.hasNext()) {
+                    FileItemStream stream = it.next();
+                    if (stream.getFieldName().contentEquals("graphql")) {
+                        inputStream = stream.openStream();
+                    }
+                }
+                if (inputStream == null) {
+                    throw new ServletException("no query found");
+                }
+            } catch (FileUploadException e) {
+                throw new ServletException("no query found");
+            }
+        } else {
+            // this is not a multipart request
+            inputStream = req.getInputStream();
+        }
+        Request request = new ObjectMapper().readValue(inputStream, Request.class);
+        Map<String,Object> variables = request.variables;
+        if (variables == null) {
+            variables = new HashMap<>();
+        }
+        query(request.query, request.operationName, variables, schema, req, resp, context);
+    }
+
+    private void query(String query, String operationName, Map<String, Object> variables, GraphQLSchema schema, HttpServletRequest req, HttpServletResponse resp, GraphQLContext context) throws IOException {
+        if (Subject.getSubject(AccessController.getContext()) == null && context.getSubject().isPresent()) {
+            Subject.doAs(context.getSubject().get(), new PrivilegedAction<Void>() {
+                @Override @SneakyThrows
+                public Void run() {
+                    query(query, operationName, variables, schema, req, resp, context);
+                    return null;
+                }
+            });
+        } else {
+            GraphQLVariables vars = new GraphQLVariables(schema, query, variables);
+            ExecutionResult result = new GraphQL(schema, executionStrategyProvider.getExecutionStrategy()).execute(query, operationName, context, vars);
+            resp.setContentType("application/json;charset=utf-8");
+            if (result.getErrors().isEmpty()) {
+                Map<String, Object> dict = new HashMap<>();
+                dict.put("data", result.getData());
+                resp.getWriter().write(new ObjectMapper().writeValueAsString(dict));
+                operationListeners.forEach(l -> l.onGraphQLOperation(context, operationName, query, vars, result.getData()));
+            } else {
+                result.getErrors().stream().
+                        filter(error -> (error instanceof ExceptionWhileDataFetching)).
+                        forEachOrdered(err -> log.error("{}", ((ExceptionWhileDataFetching) err).getException()));
+
+                resp.setStatus(500);
+                List<GraphQLError> errors = getGraphQLErrors(result);
+                Map<String, Object> dict = new HashMap<>();
+                dict.put("errors", errors);
+
+                resp.getWriter().write(new ObjectMapper().writeValueAsString(dict));
+                operationListeners.forEach(l -> l.onFailedGraphQLOperation(context, operationName, query, vars,
+                                                                           result.getErrors()));
+            }
+        }
+    }
+
+    private List<GraphQLError> getGraphQLErrors(ExecutionResult result) {
+        return result.getErrors().stream().
+                filter(error -> error instanceof InvalidSyntaxError || error instanceof ValidationError).
+                collect(Collectors.toList());
+    }
+
+    protected static class VariablesDeserializer extends JsonDeserializer<Map<String, Object>> {
+
+        @Override public Map<String, Object> deserialize(JsonParser p, DeserializationContext ctxt)
+                throws IOException {
+            Object o = p.readValueAs(Object.class);
+            if (o instanceof Map) {
+                return (Map<String, Object>) o;
+            } else if (o instanceof String) {
+                return new ObjectMapper().readValue((String) o, new TypeReference<Map<String, Object>>() {});
+            } else {
+                throw new RuntimeJsonMappingException("variables should be either an object or a string");
+            }
+        }
+    }
+
+    public static class Request {
+        @Getter
+        @Setter
+        private String query;
+        @Getter @Setter @JsonDeserialize(using = VariablesDeserializer.class)
+        private Map<String, Object> variables = new HashMap<>();
+        @Getter @Setter
+        private String operationName;
+
+    }
+}

--- a/src/main/java/graphql/servlet/GraphQLServlet.java
+++ b/src/main/java/graphql/servlet/GraphQLServlet.java
@@ -14,63 +14,28 @@
  */
 package graphql.servlet;
 
-import com.fasterxml.jackson.core.JsonParser;
-import com.fasterxml.jackson.core.type.TypeReference;
-import com.fasterxml.jackson.databind.DeserializationContext;
-import com.fasterxml.jackson.databind.JsonDeserializer;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.RuntimeJsonMappingException;
-import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
-import com.google.common.io.CharStreams;
-import graphql.*;
-import graphql.schema.GraphQLFieldDefinition;
 import graphql.schema.GraphQLObjectType;
-import graphql.schema.GraphQLSchema;
 import graphql.schema.GraphQLType;
-import graphql.validation.ValidationError;
-import lombok.Getter;
-import lombok.Setter;
-import lombok.SneakyThrows;
-import lombok.extern.slf4j.Slf4j;
-import org.apache.commons.fileupload.FileItemIterator;
-import org.apache.commons.fileupload.FileItemStream;
-import org.apache.commons.fileupload.FileUploadException;
-import org.apache.commons.fileupload.servlet.ServletFileUpload;
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
 import org.osgi.service.component.annotations.ReferenceCardinality;
 import org.osgi.service.component.annotations.ReferencePolicyOption;
 
-import javax.security.auth.Subject;
-import javax.servlet.Servlet;
-import javax.servlet.ServletException;
-import javax.servlet.http.HttpServlet;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.InputStreamReader;
-import java.security.AccessController;
-import java.security.PrivilegedAction;
-import java.util.*;
-import java.util.stream.Collectors;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
 
 import static graphql.schema.GraphQLFieldDefinition.newFieldDefinition;
 import static graphql.schema.GraphQLObjectType.newObject;
 import static graphql.schema.GraphQLSchema.newSchema;
 
-@Slf4j
 @Component(property = {"alias=/graphql", "jmx.objectname=graphql.servlet:type=graphql"})
-public class GraphQLServlet extends HttpServlet implements Servlet, GraphQLMBean, GraphQLSchemaProvider {
+public class GraphQLServlet extends AbstractGraphQLServlet {
 
     private List<GraphQLQueryProvider> queryProviders = new ArrayList<>();
     private List<GraphQLMutationProvider> mutationProviders = new ArrayList<>();
     private List<GraphQLTypesProvider> typesProviders = new ArrayList<>();
-
-    @Getter
-    GraphQLSchema schema;
-    @Getter
-    GraphQLSchema readOnlySchema;
 
     protected void updateSchema() {
         GraphQLObjectType.Builder object = newObject().name("query");
@@ -144,19 +109,6 @@ public class GraphQLServlet extends HttpServlet implements Servlet, GraphQLMBean
         updateSchema();
     }
 
-    @Override
-    public String[] getQueries() {
-        return schema.getQueryType().getFieldDefinitions().stream().map(GraphQLFieldDefinition::getName).toArray(String[]::new);
-    }
-
-    @Override
-    public String[] getMutations() {
-        return schema.getMutationType().getFieldDefinitions().stream().map(GraphQLFieldDefinition::getName).toArray(String[]::new);
-    }
-
-    private GraphQLContextBuilder contextBuilder = new DefaultGraphQLContextBuilder();
-    private ExecutionStrategyProvider executionStrategyProvider = new EnhancedExecutionStrategyProvider();
-
     @Reference(cardinality = ReferenceCardinality.OPTIONAL, policyOption = ReferencePolicyOption.GREEDY)
     public void setContextProvider(GraphQLContextBuilder contextBuilder) {
         this.contextBuilder = contextBuilder;
@@ -173,12 +125,6 @@ public class GraphQLServlet extends HttpServlet implements Servlet, GraphQLMBean
         executionStrategyProvider = new EnhancedExecutionStrategyProvider();
     }
 
-    protected GraphQLContext createContext(Optional<HttpServletRequest> req, Optional<HttpServletResponse> resp) {
-        return contextBuilder.build(req, resp);
-    }
-
-    private List<GraphQLOperationListener> operationListeners = new ArrayList<>();
-
     @Reference(cardinality = ReferenceCardinality.MULTIPLE, policyOption = ReferencePolicyOption.GREEDY)
     public void bindOperationListener(GraphQLOperationListener listener) {
         operationListeners.add(listener);
@@ -186,144 +132,5 @@ public class GraphQLServlet extends HttpServlet implements Servlet, GraphQLMBean
 
     public void unbindOperationListener(GraphQLOperationListener listener) {
         operationListeners.remove(listener);
-    }
-
-    @Override @SneakyThrows
-    public String executeQuery(String query) {
-        try {
-            ExecutionResult result = new GraphQL(schema).execute(query, createContext(Optional.empty(), Optional.empty()), new HashMap<>());
-            if (result.getErrors().isEmpty()) {
-                return new ObjectMapper().writeValueAsString(result.getData());
-            } else {
-                return new ObjectMapper().writeValueAsString(getGraphQLErrors(result));
-            }
-        } catch (Exception e) {
-            return e.getMessage();
-        }
-    }
-
-    private static class VariablesDeserializer extends JsonDeserializer<Map<String, Object>> {
-
-        @Override public Map<String, Object> deserialize(JsonParser p, DeserializationContext ctxt)
-                throws IOException {
-            Object o = p.readValueAs(Object.class);
-            if (o instanceof Map) {
-                return (Map<String, Object>) o;
-            } else if (o instanceof String) {
-                return new ObjectMapper().readValue((String) o, new TypeReference<Map<String, Object>>() {});
-            } else {
-                throw new RuntimeJsonMappingException("variables should be either an object or a string");
-            }
-        }
-    }
-
-    public static class Request {
-        @Getter @Setter
-        private String query;
-        @Getter @Setter @JsonDeserialize(using = VariablesDeserializer.class)
-        private Map<String, Object> variables = new HashMap<>();
-        @Getter @Setter
-        private String operationName;
-
-    }
-
-    @Override
-    protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException {
-        GraphQLContext context = createContext(Optional.of(req), Optional.of(resp));
-        String path = req.getPathInfo();
-        if (path == null) {
-            path = req.getServletPath();
-        }
-        if (path.contentEquals("/schema.json")) {
-            query(CharStreams.toString(new InputStreamReader(GraphQLServlet.class.getResourceAsStream("introspectionQuery"))), null, new HashMap<>(), schema, req, resp, context);
-        } else {
-            if (req.getParameter("q") != null) {
-                query(req.getParameter("q"), null, new HashMap<>(), readOnlySchema, req, resp, context);
-            } else if (req.getParameter("query") != null) {
-                Map<String,Object> variables = new HashMap<>();
-                if (req.getParameter("variables") != null) {
-                    variables.putAll(new ObjectMapper().readValue(req.getParameter("variables"), new TypeReference<Map<String,Object>>() {}));
-                }
-                String operationName = null;
-                if (req.getParameter("operationName") != null) {
-                    operationName = req.getParameter("operationName");
-                }
-                query(req.getParameter("query"), operationName, variables, readOnlySchema, req, resp, context);
-            }
-        }
-    }
-
-    @Override
-    protected void doPost(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException {
-        GraphQLContext context = createContext(Optional.of(req), Optional.of(resp));
-        InputStream inputStream = null;
-        if (ServletFileUpload.isMultipartContent(req)) {
-            ServletFileUpload upload = new ServletFileUpload();
-            try {
-                FileItemIterator it = upload.getItemIterator(req);
-                context.setFiles(Optional.of(it));
-                while (inputStream == null && it.hasNext()) {
-                    FileItemStream stream = it.next();
-                    if (stream.getFieldName().contentEquals("graphql")) {
-                        inputStream = stream.openStream();
-                    }
-                }
-                if (inputStream == null) {
-                    throw new ServletException("no query found");
-                }
-            } catch (FileUploadException e) {
-                throw new ServletException("no query found");
-            }
-        } else {
-            // this is not a multipart request
-            inputStream = req.getInputStream();
-        }
-        Request request = new ObjectMapper().readValue(inputStream, Request.class);
-        Map<String,Object> variables = request.variables;
-        if (variables == null) {
-            variables = new HashMap<>();
-        }
-        query(request.query, request.operationName, variables, schema, req, resp, context);
-    }
-
-    private void query(String query, String operationName, Map<String, Object> variables, GraphQLSchema schema, HttpServletRequest req, HttpServletResponse resp, GraphQLContext context) throws IOException {
-        if (Subject.getSubject(AccessController.getContext()) == null && context.getSubject().isPresent()) {
-            Subject.doAs(context.getSubject().get(), new PrivilegedAction<Void>() {
-                @Override @SneakyThrows
-                public Void run() {
-                    query(query, operationName, variables, schema, req, resp, context);
-                    return null;
-                }
-            });
-        } else {
-            GraphQLVariables vars = new GraphQLVariables(schema, query, variables);
-            ExecutionResult result = new GraphQL(schema, executionStrategyProvider.getExecutionStrategy()).execute(query, operationName, context, vars);
-            resp.setContentType("application/json;charset=utf-8");
-            if (result.getErrors().isEmpty()) {
-                Map<String, Object> dict = new HashMap<>();
-                dict.put("data", result.getData());
-                resp.getWriter().write(new ObjectMapper().writeValueAsString(dict));
-                operationListeners.forEach(l -> l.onGraphQLOperation(context, operationName, query, vars, result.getData()));
-            } else {
-                result.getErrors().stream().
-                        filter(error -> (error instanceof ExceptionWhileDataFetching)).
-                        forEachOrdered(err -> log.error("{}", ((ExceptionWhileDataFetching) err).getException()));
-
-                resp.setStatus(500);
-                List<GraphQLError> errors = getGraphQLErrors(result);
-                Map<String, Object> dict = new HashMap<>();
-                dict.put("errors", errors);
-
-                resp.getWriter().write(new ObjectMapper().writeValueAsString(dict));
-                operationListeners.forEach(l -> l.onFailedGraphQLOperation(context, operationName, query, vars,
-                                                                           result.getErrors()));
-            }
-        }
-    }
-
-    private List<GraphQLError> getGraphQLErrors(ExecutionResult result) {
-        return result.getErrors().stream().
-                filter(error -> error instanceof InvalidSyntaxError || error instanceof ValidationError).
-                collect(Collectors.toList());
     }
 }


### PR DESCRIPTION
In order to get a working servlet in our application with (https://github.com/Distelli/graphql-apigen), we needed a way to forego the type/mutation/query providers and provide a schema directly to the servlet.

I extracted all of the servlet logic to an abstract parent that `GraphQLServlet` now extends, in order to keep `GraphQLServlet` exactly the same as it was before but also allow us to subclass `AbstractGraphQLServlet` for our purposes.

I can add a simple implementation of the abstract parent to this project as well, if that's desired.