### PR TITLE
Extract base functionality into abstract parent

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,2 @@
-version = 0.9.2
+version = 0.10.0
 group = com.graphql-java

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,2 @@
-version = 0.10.0
+version = 0.10.1
 group = com.graphql-java

--- a/src/main/java/graphql/servlet/GraphQLOperationListener.java
+++ b/src/main/java/graphql/servlet/GraphQLOperationListener.java
@@ -20,8 +20,7 @@ import java.util.List;
 import java.util.Map;
 
 public interface GraphQLOperationListener {
-    void onGraphQLOperation(GraphQLContext context, String operationName, String query, Map<String, Object> variables,
-                            Object data);
-    void onFailedGraphQLOperation(GraphQLContext context, String operationName, String query,
-                                  Map<String, Object> variables, List<GraphQLError> errors);
+    void beforeGraphQLOperation(GraphQLContext context, String operationName, String query, Map<String, Object> variables);
+    void onSuccessfulGraphQLOperation(GraphQLContext context, String operationName, String query, Map<String, Object> variables, Object data);
+    void onFailedGraphQLOperation(GraphQLContext context, String operationName, String query, Map<String, Object> variables, List<GraphQLError> errors);
 }

--- a/src/main/java/graphql/servlet/OsgiGraphQLServlet.java
+++ b/src/main/java/graphql/servlet/OsgiGraphQLServlet.java
@@ -1,0 +1,174 @@
+/**
+ * Copyright 2016 Yurii Rashkovskii
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ */
+package graphql.servlet;
+
+import graphql.execution.ExecutionStrategy;
+import graphql.schema.GraphQLObjectType;
+import graphql.schema.GraphQLSchema;
+import graphql.schema.GraphQLType;
+import lombok.extern.slf4j.Slf4j;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+import org.osgi.service.component.annotations.ReferenceCardinality;
+import org.osgi.service.component.annotations.ReferencePolicyOption;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+
+import static graphql.schema.GraphQLFieldDefinition.newFieldDefinition;
+import static graphql.schema.GraphQLObjectType.newObject;
+import static graphql.schema.GraphQLSchema.newSchema;
+
+@Slf4j
+@Component(property = {"alias=/graphql", "jmx.objectname=graphql.servlet:type=graphql"})
+public class OsgiGraphQLServlet extends GraphQLServlet {
+
+    private List<GraphQLQueryProvider> queryProviders = new ArrayList<>();
+    private List<GraphQLMutationProvider> mutationProviders = new ArrayList<>();
+    private List<GraphQLTypesProvider> typesProviders = new ArrayList<>();
+
+    private GraphQLSchema schema;
+    private GraphQLSchema readOnlySchema;
+
+    protected void updateSchema() {
+        GraphQLObjectType.Builder object = newObject().name("query");
+
+        for (GraphQLQueryProvider provider : queryProviders) {
+            GraphQLObjectType query = provider.getQuery();
+            object.field(newFieldDefinition().
+                    type(query).
+                    staticValue(provider.context()).
+                    name(provider.getName()).
+                    description(query.getDescription()).
+                    build());
+        }
+
+        Set<GraphQLType> types = new HashSet<>();
+        for (GraphQLTypesProvider typesProvider : typesProviders) {
+            types.addAll(typesProvider.getTypes());
+        }
+
+        readOnlySchema = newSchema().query(object.build()).build(types);
+
+        if (mutationProviders.isEmpty()) {
+            schema = readOnlySchema;
+        } else {
+            GraphQLObjectType.Builder mutationObject = newObject().name("mutation");
+
+            for (GraphQLMutationProvider provider : mutationProviders) {
+                provider.getMutations().forEach(mutationObject::field);
+            }
+
+            GraphQLObjectType mutationType = mutationObject.build();
+            if (mutationType.getFieldDefinitions().size() == 0) {
+                schema = readOnlySchema;
+            } else {
+                schema = newSchema().query(object.build()).mutation(mutationType).build();
+            }
+        }
+    }
+
+    public OsgiGraphQLServlet() {
+        updateSchema();
+    }
+
+    @Reference(cardinality = ReferenceCardinality.MULTIPLE, policyOption = ReferencePolicyOption.GREEDY)
+    public void bindQueryProvider(GraphQLQueryProvider queryProvider) {
+        queryProviders.add(queryProvider);
+        updateSchema();
+    }
+    public void unbindQueryProvider(GraphQLQueryProvider queryProvider) {
+        queryProviders.remove(queryProvider);
+        updateSchema();
+    }
+
+    @Reference(cardinality = ReferenceCardinality.MULTIPLE, policyOption = ReferencePolicyOption.GREEDY)
+    public void bindMutationProvider(GraphQLMutationProvider mutationProvider) {
+        mutationProviders.add(mutationProvider);
+        updateSchema();
+    }
+    public void unbindMutationProvider(GraphQLMutationProvider mutationProvider) {
+        mutationProviders.remove(mutationProvider);
+        updateSchema();
+    }
+
+    @Reference(cardinality = ReferenceCardinality.MULTIPLE, policyOption = ReferencePolicyOption.GREEDY)
+    public void typesProviders(GraphQLTypesProvider typesProvider) {
+        typesProviders.add(typesProvider);
+        updateSchema();
+    }
+    public void unbindTypesProvider(GraphQLTypesProvider typesProvider) {
+        typesProviders.remove(typesProvider);
+        updateSchema();
+    }
+
+    private GraphQLContextBuilder contextBuilder = new DefaultGraphQLContextBuilder();
+    private ExecutionStrategyProvider executionStrategyProvider = new EnhancedExecutionStrategyProvider();
+
+    @Reference(cardinality = ReferenceCardinality.OPTIONAL, policyOption = ReferencePolicyOption.GREEDY)
+    public void setContextProvider(GraphQLContextBuilder contextBuilder) {
+        this.contextBuilder = contextBuilder;
+    }
+    public void unsetContextProvider(GraphQLContextBuilder contextBuilder) {
+        this.contextBuilder = new DefaultGraphQLContextBuilder();
+    }
+
+    @Reference(cardinality = ReferenceCardinality.OPTIONAL)
+    public void setExecutionStrategyProvider(ExecutionStrategyProvider provider) {
+        executionStrategyProvider = provider;
+    }
+    public void unsetExecutionStrategyProvider(ExecutionStrategyProvider provider) {
+        executionStrategyProvider = new EnhancedExecutionStrategyProvider();
+    }
+
+    protected GraphQLContext createContext(Optional<HttpServletRequest> req, Optional<HttpServletResponse> resp) {
+        return contextBuilder.build(req, resp);
+    }
+
+    @Override
+    protected ExecutionStrategy getExecutionStrategy() {
+        return executionStrategyProvider.getExecutionStrategy();
+    }
+
+    @Override
+    protected Map<String, Object> transformVariables(GraphQLSchema schema, String query, Map<String, Object> variables) {
+        return new GraphQLVariables(schema, query, variables);
+    }
+
+    @Reference(cardinality = ReferenceCardinality.MULTIPLE, policyOption = ReferencePolicyOption.GREEDY)
+    public void bindOperationListener(GraphQLOperationListener listener) {
+        addOperationListener(listener);
+    }
+
+    public void unbindOperationListener(GraphQLOperationListener listener) {
+        removeOperationListener(listener);
+    }
+
+    @Override
+    public GraphQLSchema getSchema() {
+        return schema;
+    }
+
+    @Override
+    public GraphQLSchema getReadOnlySchema() {
+        return readOnlySchema;
+    }
+}

--- a/src/main/java/graphql/servlet/SimpleGraphQLServlet.java
+++ b/src/main/java/graphql/servlet/SimpleGraphQLServlet.java
@@ -1,0 +1,51 @@
+package graphql.servlet;
+
+import graphql.execution.ExecutionStrategy;
+import graphql.schema.GraphQLSchema;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.util.Map;
+import java.util.Optional;
+
+/**
+ * @author Andrew Potter
+ */
+public class SimpleGraphQLServlet extends GraphQLServlet {
+
+    public SimpleGraphQLServlet(GraphQLSchema schema, ExecutionStrategy executionStrategy) {
+        this.schema = schema;
+        this.readOnlySchema = new GraphQLSchema(schema.getQueryType(), null, schema.getDictionary());
+
+        this.executionStrategy = executionStrategy;
+    }
+
+    private final GraphQLSchema schema;
+    private final GraphQLSchema readOnlySchema;
+    private final ExecutionStrategy executionStrategy;
+
+    @Override
+    public GraphQLSchema getSchema() {
+        return schema;
+    }
+
+    @Override
+    public GraphQLSchema getReadOnlySchema() {
+        return readOnlySchema;
+    }
+
+    @Override
+    protected GraphQLContext createContext(Optional<HttpServletRequest> request, Optional<HttpServletResponse> response) {
+        return new GraphQLContext(request, response);
+    }
+
+    @Override
+    protected ExecutionStrategy getExecutionStrategy() {
+        return executionStrategy;
+    }
+
+    @Override
+    protected Map<String, Object> transformVariables(GraphQLSchema schema, String query, Map<String, Object> variables) {
+        return variables;
+    }
+}

--- a/src/main/java/graphql/servlet/SimpleGraphQLServlet.java
+++ b/src/main/java/graphql/servlet/SimpleGraphQLServlet.java
@@ -1,3 +1,17 @@
+/**
+ * Copyright 2016 Yurii Rashkovskii
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ */
 package graphql.servlet;
 
 import graphql.execution.ExecutionStrategy;

--- a/src/test/java/graphql/servlet/GraphQLServletTest.java
+++ b/src/test/java/graphql/servlet/GraphQLServletTest.java
@@ -62,16 +62,16 @@ public class GraphQLServletTest {
 
     @Test
     public void queryProvider() {
-        GraphQLServlet servlet = new GraphQLServlet();
+        OsgiGraphQLServlet servlet = new OsgiGraphQLServlet();
         TestQueryProvider queryProvider = new TestQueryProvider();
         servlet.bindQueryProvider(queryProvider);
-        GraphQLFieldDefinition query = servlet.schema.getQueryType().getFieldDefinition("query");
+        GraphQLFieldDefinition query = servlet.getSchema().getQueryType().getFieldDefinition("query");
         assertEquals(query.getType().getName(), "query");
-        query = servlet.readOnlySchema.getQueryType().getFieldDefinition("query");
+        query = servlet.getReadOnlySchema().getQueryType().getFieldDefinition("query");
         assertEquals(query.getType().getName(), "query");
         servlet.unbindQueryProvider(queryProvider);
-        assertTrue(servlet.schema.getQueryType().getFieldDefinitions().isEmpty());
-        assertTrue(servlet.readOnlySchema.getQueryType().getFieldDefinitions().isEmpty());
+        assertTrue(servlet.getSchema().getQueryType().getFieldDefinitions().isEmpty());
+        assertTrue(servlet.getReadOnlySchema().getQueryType().getFieldDefinitions().isEmpty());
     }
 
     public static class TestMutationProvider implements GraphQLMutationProvider {
@@ -84,18 +84,18 @@ public class GraphQLServletTest {
 
     @Test
     public void mutationProvider() {
-        GraphQLServlet servlet = new GraphQLServlet();
+        OsgiGraphQLServlet servlet = new OsgiGraphQLServlet();
         TestMutationProvider mutationProvider = new TestMutationProvider();
         servlet.bindMutationProvider(mutationProvider);
-        assertTrue(servlet.schema.getMutationType().getFieldDefinition("int").getType().equals(GraphQLInt));
-        assertNull(servlet.readOnlySchema.getMutationType());
+        assertTrue(servlet.getSchema().getMutationType().getFieldDefinition("int").getType().equals(GraphQLInt));
+        assertNull(servlet.getReadOnlySchema().getMutationType());
         servlet.unbindMutationProvider(mutationProvider);
-        assertNull(servlet.schema.getMutationType());
+        assertNull(servlet.getSchema().getMutationType());
     }
 
     @Test @SneakyThrows
     public void schema() {
-        GraphQLServlet servlet = new GraphQLServlet();
+        OsgiGraphQLServlet servlet = new OsgiGraphQLServlet();
 
         HttpServletRequest req = mock(HttpServletRequest.class);
         when(req.getPathInfo()).thenReturn("/schema.json");

--- a/src/test/java/graphql/servlet/GraphQLVariablesTest.java
+++ b/src/test/java/graphql/servlet/GraphQLVariablesTest.java
@@ -32,7 +32,6 @@ public class GraphQLVariablesTest {
 
     public static class ComplexQueryProvider implements GraphQLQueryProvider {
 
-
         @Value
         public static class Data {
             @GraphQLField
@@ -72,7 +71,7 @@ public class GraphQLVariablesTest {
 
     @Test
     public void variableTyping() {
-        GraphQLServlet servlet = new GraphQLServlet();
+        OsgiGraphQLServlet servlet = new OsgiGraphQLServlet();
         ComplexQueryProvider queryProvider = new ComplexQueryProvider();
         servlet.bindQueryProvider(queryProvider);
         GraphQLSchema schema = servlet.getSchema();
@@ -92,7 +91,7 @@ public class GraphQLVariablesTest {
 
     @Test
     public void nonNullvariableTyping() {
-        GraphQLServlet servlet = new GraphQLServlet();
+        OsgiGraphQLServlet servlet = new OsgiGraphQLServlet();
         ComplexQueryProvider queryProvider = new ComplexQueryProvider();
         servlet.bindQueryProvider(queryProvider);
         GraphQLSchema schema = servlet.getSchema();
@@ -107,5 +106,4 @@ public class GraphQLVariablesTest {
         assertEquals(((ComplexQueryProvider.Data)d).getField1(), "1");
         assertEquals(((ComplexQueryProvider.Data)d).getField2(), "2");
     }
-
 }


### PR DESCRIPTION
This pull creates an abstract parent with the barebones "meat and potatoes" of the servlet.  This makes the project fully extensible, allowing for custom implementations without copy/paste.

This is a refinement of #14, chosen over the approach of #15 for reasons listed in that PR.