### PR TITLE
Root type name changes & query provider API changes

### DIFF
--- a/src/main/java/graphql/servlet/GraphQLQueryProvider.java
+++ b/src/main/java/graphql/servlet/GraphQLQueryProvider.java
@@ -15,7 +15,6 @@
 package graphql.servlet;
 
 import graphql.schema.GraphQLFieldDefinition;
-import graphql.schema.GraphQLObjectType;
 
 import java.util.Collection;
 
@@ -27,25 +26,6 @@ public interface GraphQLQueryProvider {
     /**
      * @return a collection of field definitions that will be added to the root query type.
      */
-    default Collection<GraphQLFieldDefinition> getQueryFieldDefinitions() { return null; }
+    Collection<GraphQLFieldDefinition> getQueryFieldDefinitions();
 
-    /**
-     * @deprecated use query field definitions instead
-     * @return a GraphQL object type to add to the root query type
-     */
-    default GraphQLObjectType getQuery() { return null; }
-
-    /**
-     * @deprecated use query field definitions instead
-     * @return an object that will be used as a staticValue for the root query type field
-     */
-    default Object context() { return null; }
-
-    /**
-     * @deprecated use query field definitions instead
-     * @return the name to use for the field for this query provider in the root query type
-     */
-    default String getName() {
-        return getQuery().getName();
-    }
 }

--- a/src/main/java/graphql/servlet/GraphQLQueryProvider.java
+++ b/src/main/java/graphql/servlet/GraphQLQueryProvider.java
@@ -25,10 +25,9 @@ import java.util.Collection;
 public interface GraphQLQueryProvider {
 
     /**
-     * @return a collection of field definitions that will be added to the root query type. It is allowed to return null
-     * or an empty array (for example for migration purposes from the old API to this one).
+     * @return a collection of field definitions that will be added to the root query type.
      */
-    Collection<GraphQLFieldDefinition> getQueryFieldDefinitions();
+    default Collection<GraphQLFieldDefinition> getQueryFieldDefinitions() { return null; }
 
     /**
      * @deprecated use query field definitions instead

--- a/src/main/java/graphql/servlet/GraphQLQueryProvider.java
+++ b/src/main/java/graphql/servlet/GraphQLQueryProvider.java
@@ -14,11 +14,37 @@
  */
 package graphql.servlet;
 
+import graphql.schema.GraphQLFieldDefinition;
 import graphql.schema.GraphQLObjectType;
 
+import java.util.Collection;
+
+/**
+ * This interface is used by OSGi bundles to plugin new field into the root query type
+ */
 public interface GraphQLQueryProvider {
-    GraphQLObjectType getQuery();
-    Object context();
+
+    /**
+     * @return a collection of field definitions that will be added to the root query type.
+     */
+    Collection<GraphQLFieldDefinition> getQueryFieldDefinitions();
+
+    /**
+     * @deprecated use query field definitions instead
+     * @return a GraphQL object type to add to the root query type
+     */
+    default GraphQLObjectType getQuery() { return null; }
+
+    /**
+     * @deprecated use query field definitions instead
+     * @return an object that will be used as a staticValue for the root query type field
+     */
+    default Object context() { return null; }
+
+    /**
+     * @deprecated use query field definitions instead
+     * @return the name to use for the field for this query provider in the root query type
+     */
     default String getName() {
         return getQuery().getName();
     }

--- a/src/main/java/graphql/servlet/GraphQLQueryProvider.java
+++ b/src/main/java/graphql/servlet/GraphQLQueryProvider.java
@@ -26,6 +26,6 @@ public interface GraphQLQueryProvider {
     /**
      * @return a collection of field definitions that will be added to the root query type.
      */
-    Collection<GraphQLFieldDefinition> getQueryFieldDefinitions();
+    Collection<GraphQLFieldDefinition> getQueries();
 
 }

--- a/src/main/java/graphql/servlet/GraphQLQueryProvider.java
+++ b/src/main/java/graphql/servlet/GraphQLQueryProvider.java
@@ -25,7 +25,8 @@ import java.util.Collection;
 public interface GraphQLQueryProvider {
 
     /**
-     * @return a collection of field definitions that will be added to the root query type.
+     * @return a collection of field definitions that will be added to the root query type. It is allowed to return null
+     * or an empty array (for example for migration purposes from the old API to this one).
      */
     Collection<GraphQLFieldDefinition> getQueryFieldDefinitions();
 

--- a/src/main/java/graphql/servlet/OsgiGraphQLServlet.java
+++ b/src/main/java/graphql/servlet/OsgiGraphQLServlet.java
@@ -34,7 +34,6 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 
-import static graphql.schema.GraphQLFieldDefinition.newFieldDefinition;
 import static graphql.schema.GraphQLObjectType.newObject;
 import static graphql.schema.GraphQLSchema.newSchema;
 
@@ -56,15 +55,6 @@ public class OsgiGraphQLServlet extends GraphQLServlet {
         GraphQLObjectType.Builder object = newObject().name("Query").description("Root query type");
 
         for (GraphQLQueryProvider provider : queryProviders) {
-            GraphQLObjectType query = provider.getQuery();
-            if (query != null) {
-                object.field(newFieldDefinition().
-                        type(query).
-                        staticValue(provider.context()).
-                        name(provider.getName()).
-                        description(query.getDescription()).
-                        build());
-            }
             if (provider.getQueryFieldDefinitions() != null && provider.getQueryFieldDefinitions().size() > 0) {
                 for (GraphQLFieldDefinition graphQLFieldDefinition : provider.getQueryFieldDefinitions()) {
                     object.field(graphQLFieldDefinition);

--- a/src/main/java/graphql/servlet/OsgiGraphQLServlet.java
+++ b/src/main/java/graphql/servlet/OsgiGraphQLServlet.java
@@ -38,7 +38,10 @@ import static graphql.schema.GraphQLObjectType.newObject;
 import static graphql.schema.GraphQLSchema.newSchema;
 
 @Slf4j
-@Component(property = {"alias=/graphql", "jmx.objectname=graphql.servlet:type=graphql"})
+@Component(
+        service=javax.servlet.http.HttpServlet.class,
+        property = {"alias=/graphql", "jmx.objectname=graphql.servlet:type=graphql"}
+)
 public class OsgiGraphQLServlet extends GraphQLServlet {
 
     private List<GraphQLQueryProvider> queryProviders = new ArrayList<>();

--- a/src/main/java/graphql/servlet/OsgiGraphQLServlet.java
+++ b/src/main/java/graphql/servlet/OsgiGraphQLServlet.java
@@ -55,8 +55,8 @@ public class OsgiGraphQLServlet extends GraphQLServlet {
         GraphQLObjectType.Builder object = newObject().name("Query").description("Root query type");
 
         for (GraphQLQueryProvider provider : queryProviders) {
-            if (provider.getQueryFieldDefinitions() != null && provider.getQueryFieldDefinitions().size() > 0) {
-                for (GraphQLFieldDefinition graphQLFieldDefinition : provider.getQueryFieldDefinitions()) {
+            if (provider.getQueries() != null && provider.getQueries().size() > 0) {
+                for (GraphQLFieldDefinition graphQLFieldDefinition : provider.getQueries()) {
                     object.field(graphQLFieldDefinition);
                 }
             }

--- a/src/test/groovy/graphql/servlet/GraphQLVariablesSpec.groovy
+++ b/src/test/groovy/graphql/servlet/GraphQLVariablesSpec.groovy
@@ -17,14 +17,28 @@ package graphql.servlet
 import graphql.annotations.GraphQLAnnotations
 import graphql.annotations.GraphQLField
 import graphql.annotations.GraphQLName
+import graphql.schema.GraphQLFieldDefinition
 import graphql.schema.GraphQLObjectType
 import graphql.schema.GraphQLSchema
 import lombok.SneakyThrows
 import spock.lang.Specification
 
+import static graphql.schema.GraphQLFieldDefinition.newFieldDefinition
+
 class GraphQLVariablesSpec extends Specification {
 
     static class ComplexQueryProvider implements GraphQLQueryProvider {
+
+        @Override
+        Collection<GraphQLFieldDefinition> getQueryFieldDefinitions() {
+            List<GraphQLFieldDefinition> fieldDefinitions = new ArrayList<>();
+            fieldDefinitions.add(newFieldDefinition()
+                    .name("data")
+                    .type(GraphQLAnnotations.object(DataQuery.class))
+                    .staticValue(new DataQuery())
+                    .build());
+            return fieldDefinitions;
+        }
 
         static class Data {
             @GraphQLField
@@ -48,16 +62,6 @@ class GraphQLVariablesSpec extends Specification {
             }
         }
 
-        @Override
-        @SneakyThrows
-        GraphQLObjectType getQuery() {
-            return GraphQLAnnotations.object(DataQuery.class)
-        }
-
-        @Override
-        Object context() {
-            return new DataQuery()
-        }
     }
 
     GraphQLSchema schema

--- a/src/test/groovy/graphql/servlet/GraphQLVariablesSpec.groovy
+++ b/src/test/groovy/graphql/servlet/GraphQLVariablesSpec.groovy
@@ -30,7 +30,7 @@ class GraphQLVariablesSpec extends Specification {
     static class ComplexQueryProvider implements GraphQLQueryProvider {
 
         @Override
-        Collection<GraphQLFieldDefinition> getQueryFieldDefinitions() {
+        Collection<GraphQLFieldDefinition> getQueries() {
             List<GraphQLFieldDefinition> fieldDefinitions = new ArrayList<>();
             fieldDefinitions.add(newFieldDefinition()
                     .name("data")

--- a/src/test/groovy/graphql/servlet/OsgiGraphQLServletSpec.groovy
+++ b/src/test/groovy/graphql/servlet/OsgiGraphQLServletSpec.groovy
@@ -30,7 +30,7 @@ class OsgiGraphQLServletSpec extends Specification {
     static class TestQueryProvider implements GraphQLQueryProvider {
 
         @Override
-        Collection<GraphQLFieldDefinition> getQueryFieldDefinitions() {
+        Collection<GraphQLFieldDefinition> getQueries() {
             List<GraphQLFieldDefinition> fieldDefinitions = new ArrayList<>();
             fieldDefinitions.add(newFieldDefinition()
                     .name("query")

--- a/src/test/groovy/graphql/servlet/OsgiGraphQLServletSpec.groovy
+++ b/src/test/groovy/graphql/servlet/OsgiGraphQLServletSpec.groovy
@@ -29,22 +29,23 @@ class OsgiGraphQLServletSpec extends Specification {
 
     static class TestQueryProvider implements GraphQLQueryProvider {
 
+        @Override
+        Collection<GraphQLFieldDefinition> getQueryFieldDefinitions() {
+            List<GraphQLFieldDefinition> fieldDefinitions = new ArrayList<>();
+            fieldDefinitions.add(newFieldDefinition()
+                    .name("query")
+                    .type(GraphQLAnnotations.object(Query.class))
+                    .staticValue(new Query())
+                    .build());
+            return fieldDefinitions;
+        }
+
         @GraphQLName("query")
         static class Query {
             @GraphQLField
             public String field;
         }
 
-        @Override
-        @SneakyThrows
-        GraphQLObjectType getQuery() {
-            return GraphQLAnnotations.object(Query.class);
-        }
-
-        @Override
-        Object context() {
-            return new Query();
-        }
     }
 
     def "query provider adds query objects"() {


### PR DESCRIPTION
Hello,
I'd like to propose the following changes: 
- Renaming the root query and mutation types from "query" and "mutation" to "Query" and "Mutation" to follow object type naming conventions
- Modified the GraphQLQueryProvider implementation to make the old API deprecated and replace with a collection of field definitions, making this aligned with the GraphQLMutationProvider interface. This makes it possible to define data fetcher for the root object type fields.
- Added JavaDoc documentation to the GraphQLQueryProvider interface

I think these changes would make the exposed GraphQL API a lot cleaner and also a lot more flexible. The inability to use data fetchers on the fields or list types in the root object types is a very strong limitation.

If these changes are approved I'd be willing to update the README to give some more documentation on how to use the new API.

In order to keep the API compatible, all the methods in the GraphQLQueryProvider are now optional, but over time we should change this to remove the methods now marked as deprecated.

The name change for the root object types should not have major impacts, these are just types names but they should be noted as well. Btw I noticed that the SimpleGraphQLServlet also uses a capitalized "Mutation" type so this is consistent with these changes.
