### PR TITLE
Revert change to OSGi R6 Property back to a property compatible with …

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ build
 *.ipr
 *.iws
 .idea/
+target

--- a/src/main/java/graphql/servlet/OsgiGraphQLServlet.java
+++ b/src/main/java/graphql/servlet/OsgiGraphQLServlet.java
@@ -38,7 +38,7 @@ import static graphql.schema.GraphQLSchema.newSchema;
 
 @Component(
         service={javax.servlet.http.HttpServlet.class,javax.servlet.Servlet.class},
-        property = {"osgi.http.whiteboard.servlet.pattern=/graphql/*", "jmx.objectname=graphql.servlet:type=graphql"}
+        property = {"alias=/graphql", "jmx.objectname=graphql.servlet:type=graphql"}
 )
 public class OsgiGraphQLServlet extends GraphQLServlet {
 


### PR DESCRIPTION
…older OSGi containers

I'd like to revert this change because after testing with multiple OSGi containers it seems that few of them support the new OSGi R6 property fully.

Probably a better solution would be to have an activator register the servlet depending on the version of the OSGi container but in the meantime I think it is better to go back to the old property.