### PR TITLE
Provide a common interface to register Query/Mutation/TypesProviders …

### DIFF
--- a/src/main/java/graphql/servlet/GraphQLMutationProvider.java
+++ b/src/main/java/graphql/servlet/GraphQLMutationProvider.java
@@ -18,6 +18,6 @@ import graphql.schema.GraphQLFieldDefinition;
 
 import java.util.Collection;
 
-public interface GraphQLMutationProvider {
+public interface GraphQLMutationProvider extends GraphQLProvider {
     Collection<GraphQLFieldDefinition> getMutations();
 }

--- a/src/main/java/graphql/servlet/GraphQLProvider.java
+++ b/src/main/java/graphql/servlet/GraphQLProvider.java
@@ -14,10 +14,5 @@
  */
 package graphql.servlet;
 
-import graphql.schema.GraphQLType;
-
-import java.util.Collection;
-
-public interface GraphQLTypesProvider extends GraphQLProvider {
-    Collection<GraphQLType> getTypes();
+public interface GraphQLProvider {
 }

--- a/src/main/java/graphql/servlet/GraphQLQueryProvider.java
+++ b/src/main/java/graphql/servlet/GraphQLQueryProvider.java
@@ -21,7 +21,7 @@ import java.util.Collection;
 /**
  * This interface is used by OSGi bundles to plugin new field into the root query type
  */
-public interface GraphQLQueryProvider {
+public interface GraphQLQueryProvider extends GraphQLProvider {
 
     /**
      * @return a collection of field definitions that will be added to the root query type.

--- a/src/main/java/graphql/servlet/OsgiGraphQLServlet.java
+++ b/src/main/java/graphql/servlet/OsgiGraphQLServlet.java
@@ -89,6 +89,32 @@ public class OsgiGraphQLServlet extends GraphQLServlet {
     }
 
     @Reference(cardinality = ReferenceCardinality.MULTIPLE, policyOption = ReferencePolicyOption.GREEDY)
+    public void bindProvider(GraphQLProvider provider) {
+        if (provider instanceof GraphQLQueryProvider) {
+            queryProviders.add((GraphQLQueryProvider) provider);
+        }
+        if (provider instanceof GraphQLMutationProvider) {
+            mutationProviders.add((GraphQLMutationProvider) provider);
+        }
+        if (provider instanceof GraphQLTypesProvider) {
+            typesProviders.add((GraphQLTypesProvider) provider);
+        }
+        updateSchema();
+    }
+    public void unbindProvider(GraphQLProvider provider) {
+        if (provider instanceof GraphQLQueryProvider) {
+            queryProviders.remove((GraphQLQueryProvider) provider);
+        }
+        if (provider instanceof GraphQLMutationProvider) {
+            mutationProviders.remove((GraphQLMutationProvider) provider);
+        }
+        if (provider instanceof GraphQLTypesProvider) {
+            typesProviders.remove((GraphQLTypesProvider) provider);
+        }
+        updateSchema();
+    }
+
+    @Reference(cardinality = ReferenceCardinality.MULTIPLE, policyOption = ReferencePolicyOption.GREEDY)
     public void bindQueryProvider(GraphQLQueryProvider queryProvider) {
         queryProviders.add(queryProvider);
         updateSchema();


### PR DESCRIPTION
…in one single bind operation.
An updateSchema is triggered everytime a new provider is bound - so if you need to provide QueryProvider / MutationProvider and TypesProvider , the updateSchema() will be called 3 times. 
Also, the 3 services will be bound in random order - if QueryProvider or MutationProvider has references to types defined in TypesProvider, the first updateSchemas() will throw exceptions, complaining about undefined types.
Having one single service in a bundle providing everything avoid this issue, and will update the schema only once.
