### PR TITLE
Check if inner exception is of type GraphQLError in DefaultGraphQLErrorHandler

### DIFF
--- a/src/main/java/graphql/servlet/DefaultGraphQLErrorHandler.java
+++ b/src/main/java/graphql/servlet/DefaultGraphQLErrorHandler.java
@@ -44,6 +44,9 @@ public class DefaultGraphQLErrorHandler implements GraphQLErrorHandler {
     }
 
     protected boolean isClientError(GraphQLError error) {
-        return !(error instanceof ExceptionWhileDataFetching || error instanceof Throwable);
+        if (error instanceof ExceptionWhileDataFetching) {
+            return ((ExceptionWhileDataFetching) error).getException() instanceof GraphQLError;
+        }
+        return !(error instanceof Throwable);
     }
 }

--- a/src/test/groovy/graphql/servlet/TestGraphQLErrorException.groovy
+++ b/src/test/groovy/graphql/servlet/TestGraphQLErrorException.groovy
@@ -1,0 +1,32 @@
+package graphql.servlet
+
+import graphql.ErrorType
+import graphql.GraphQLError
+import graphql.language.SourceLocation
+
+/**
+ * @author Andrew Potter
+ */
+class TestGraphQLErrorException extends RuntimeException implements GraphQLError {
+
+    public TestGraphQLErrorException(String message) {
+        super(message);
+    }
+
+    @Override
+    public Map<String, Object> getExtensions() {
+        Map<String, Object> customAttributes = new LinkedHashMap<>();
+        customAttributes.put("foo", "bar");
+        return customAttributes;
+    }
+
+    @Override
+    List<SourceLocation> getLocations() {
+        return null
+    }
+
+    @Override
+    ErrorType getErrorType() {
+        return ErrorType.ValidationError;
+    }
+}


### PR DESCRIPTION
According to the `graphql-java` documentation, ["Error while fetching data"](https://graphql-java.readthedocs.io/en/v6/execution.html#exceptions-while-fetching-data), it says:

> If the exception you throw is itself a GraphqlError then it will transfer the message and custom extensions attributes from that exception into the ExceptionWhileDataFetching object. This allows you to place your own custom attributes into the graphql error that is sent back to the caller.

In `graphql.execution.SimpleDataFetcherExceptionHandler`, all exceptions are wrapped in a `graphql.ExceptionWhileDataFetching`. To maintain the functionality as described in the `graphql-java`-docs we need to check if the inner exception in `graphql.servlet.DefaultGraphQLErrorHandler.java:47` is of type `GraphQLError`, in which case it should be a client error.

I'm not 100% sure of these assumptions, but in our case this would make sense. If not, we would have no way of passing errors through to the caller without implementing our own ExecutionStrategy.

Relates to #50.