### PR TITLE
Add extensions to the response map as per the spec

### DIFF
--- a/src/main/java/graphql/servlet/GraphQLServletListener.java
+++ b/src/main/java/graphql/servlet/GraphQLServletListener.java
@@ -25,8 +25,8 @@ public interface GraphQLServletListener {
     }
 
     interface OperationCallback {
-        default void onSuccess(GraphQLContext context, String operationName, String query, Map<String, Object> variables, Object data) {}
-        default void onError(GraphQLContext context, String operationName, String query, Map<String, Object> variables, Object data, List<GraphQLError> errors) {}
-        default void onFinally(GraphQLContext context, String operationName, String query, Map<String, Object> variables, Object data) {}
+        default void onSuccess(GraphQLContext context, String operationName, String query, Map<String, Object> variables, Object data, Object extensions) {}
+        default void onError(GraphQLContext context, String operationName, String query, Map<String, Object> variables, Object data, List<GraphQLError> errors, Object extensions) {}
+        default void onFinally(GraphQLContext context, String operationName, String query, Map<String, Object> variables, Object data, Object extensions) {}
     }
 }


### PR DESCRIPTION
The [GraphQL spec](http://facebook.github.io/graphql/October2016/#sec-Response-Format) mentions an `extensions` entry in the response map that implementors can use to provide additional information for a GraphQL request.  For instance, the [TracingInstrumentation](graphql-java/src/main/java/graphql/execution/instrumentation/tracing/TracingInstrumentation.java) will capture tracing information and populate the extensions field on the ExecutionResult.  This change passes along the `extensions` from the `ExecutionResult` (if any exist).