### PR TITLE
Fix problem when implemente listener based in GraphQLServletListener

### DIFF
--- a/src/main/java/graphql/servlet/GraphQLServlet.java
+++ b/src/main/java/graphql/servlet/GraphQLServlet.java
@@ -252,8 +252,8 @@ public abstract class GraphQLServlet extends HttpServlet implements Servlet, Gra
         List<GraphQLServletListener.RequestCallback> requestCallbacks = runListeners(l -> l.onRequest(request, response));
 
         try {
-            handler.handle(request, response);
             runCallbacks(requestCallbacks, c -> c.onSuccess(request, response));
+            handler.handle(request, response);
         } catch (Throwable t) {
             response.setStatus(500);
             log.error("Error executing GraphQL request!", t);
@@ -394,11 +394,7 @@ public abstract class GraphQLServlet extends HttpServlet implements Servlet, Gra
 
     private <T> void runCallbacks(List<T> callbacks, Consumer<T> action) {
         callbacks.forEach(callback -> {
-            try {
-                action.accept(callback);
-            } catch (Throwable t) {
-                log.error("Error running callback: {}", callback, t);
-            }
+            action.accept(callback);
         });
     }
 


### PR DESCRIPTION
When a custom GraphQLServletListener is added and it throw an error, the request continues without any effect.