### PR TITLE
SimpleGraphQLServlet: protected constructor with Builder

### DIFF
--- a/src/main/java/graphql/servlet/SimpleGraphQLServlet.java
+++ b/src/main/java/graphql/servlet/SimpleGraphQLServlet.java
@@ -90,7 +90,7 @@ public class SimpleGraphQLServlet extends GraphQLServlet {
         }
     }
 
-    private SimpleGraphQLServlet(Builder builder) {
+    protected SimpleGraphQLServlet(Builder builder) {
         super(builder.objectMapperConfigurer, builder.listeners, null);
 
         this.schemaProvider = builder.schemaProvider;


### PR DESCRIPTION
I have servlet which extends `SimpleGraphQLServlet`. After recent change which added builder all `SimpleGraphQLServlet` constructors are either deprecated or not accessible. This PR makes the new constructor with builder accessible to derived classes.