### PR TITLE
Changes to look ahead in isBatchedQuery

### DIFF
--- a/src/main/java/graphql/servlet/GraphQLServlet.java
+++ b/src/main/java/graphql/servlet/GraphQLServlet.java
@@ -439,11 +439,12 @@ public abstract class GraphQLServlet extends HttpServlet implements Servlet, Gra
             return false;
         }
 
+        final int BUFFER_LENGTH = 128;
         ByteArrayOutputStream result = new ByteArrayOutputStream();
-        byte[] buffer = new byte[128];
+        byte[] buffer = new byte[BUFFER_LENGTH];
         int length;
 
-        inputStream.mark(0);
+        inputStream.mark(BUFFER_LENGTH);
         while ((length = inputStream.read(buffer)) != -1) {
             result.write(buffer, 0, length);
             String chunk = result.toString();


### PR DESCRIPTION
Simple change to ensure that the readlimit passed into InputStream.mark matches the length of the read buffer. This ensures that when InputStream.reset is called the stream is reset correctly. A test has also been added to ensure this behaviour.

The reason for this pull request is outlined in the [issue #61](https://github.com/graphql-java/graphql-java-servlet/issues/61).