### PR TITLE
Add support for an 'operations' part when doing a multipart POST.

### DIFF
--- a/src/main/java/graphql/servlet/AbstractGraphQLHttpServlet.java
+++ b/src/main/java/graphql/servlet/AbstractGraphQLHttpServlet.java
@@ -23,6 +23,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.Writer;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
@@ -33,7 +34,6 @@ import java.util.function.BiConsumer;
 import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 /**
  * @author Andrew Potter
@@ -48,6 +48,7 @@ public abstract class AbstractGraphQLHttpServlet extends HttpServlet implements 
     public static final int STATUS_BAD_REQUEST = 400;
 
     private static final GraphQLRequest INTROSPECTION_REQUEST = new GraphQLRequest(IntrospectionQuery.INTROSPECTION_QUERY, new HashMap<>(), null);
+    private static final String[] MULTIPART_KEYS = new String[]{"operations", "graphql", "query"};
 
     protected abstract GraphQLQueryInvoker getQueryInvoker();
 
@@ -114,109 +115,58 @@ public abstract class AbstractGraphQLHttpServlet extends HttpServlet implements 
                     String query = CharStreams.toString(request.getReader());
                     query(queryInvoker, graphQLObjectMapper, invocationInputFactory.create(new GraphQLRequest(query, null, null)), response);
                 } else if (request.getContentType() != null && request.getContentType().startsWith("multipart/form-data") && !request.getParts().isEmpty()) {
-                    final Map<String, List<Part>> fileItems = request.getParts().stream()
-                            .collect(Collectors.toMap(
-                                    Part::getName,
-                                    Collections::singletonList,
-                                    (l1, l2) -> Stream.concat(l1.stream(), l2.stream()).collect(Collectors.toList())));
+                    final Map<String, List<Part>> fileItems = request.getParts()
+                                                                     .stream()
+                                                                     .collect(Collectors.groupingBy(Part::getName));
 
-                    if(fileItems.containsKey("operations")) {
-                        final Optional<Part> queryItem = getFileItem(fileItems, "operations");
-                        if (queryItem.isPresent()) {
-                            InputStream inputStream = queryItem.get().getInputStream();
-
-                            if (!inputStream.markSupported()) {
-                                inputStream = new BufferedInputStream(inputStream);
-                            }
-
-                            final Optional<Map<String, List<String>>> variablesMap =
-                                getFileItem(fileItems, "map")
-                                    .map(graphQLObjectMapper::deserializeMultipartMap);
-
-                            if (isBatchedQuery(inputStream)) {
-                                List<GraphQLRequest> graphQLRequests = graphQLObjectMapper.readBatchedGraphQLRequest(inputStream);
-                                variablesMap.ifPresent(map -> graphQLRequests.forEach(r -> mapMultipartVariables(r, map, fileItems)));
-                                GraphQLBatchedInvocationInput invocationInput = invocationInputFactory.create(graphQLRequests, request);
-                                invocationInput.getContext().setFiles(fileItems);
-                                queryBatched(queryInvoker, graphQLObjectMapper, invocationInput, response);
-                                return;
-                            } else {
-                                GraphQLRequest graphQLRequest = graphQLObjectMapper.readGraphQLRequest(inputStream);
-                                variablesMap.ifPresent(m -> mapMultipartVariables(graphQLRequest, m, fileItems));
-                                GraphQLSingleInvocationInput invocationInput =
-                                    invocationInputFactory.create(graphQLRequest, request);
-                                invocationInput.getContext().setFiles(fileItems);
-                                query(queryInvoker, graphQLObjectMapper, invocationInput, response);
-                                return;
-                            }
+                    for (String key : MULTIPART_KEYS) {
+                        // Check to see if there is a part under the key we seek
+                        if(!fileItems.containsKey(key)) {
+                            continue;
                         }
-                    } else if (fileItems.containsKey("graphql")) {
-                        final Optional<Part> graphqlItem = getFileItem(fileItems, "graphql");
-                        if (graphqlItem.isPresent()) {
-                            InputStream inputStream = graphqlItem.get().getInputStream();
 
-                            if (!inputStream.markSupported()) {
-                                inputStream = new BufferedInputStream(inputStream);
-                            }
-
-                            if (isBatchedQuery(inputStream)) {
-                                GraphQLBatchedInvocationInput invocationInput = invocationInputFactory.create(graphQLObjectMapper.readBatchedGraphQLRequest(inputStream), request);
-                                invocationInput.getContext().setFiles(fileItems);
-                                queryBatched(queryInvoker, graphQLObjectMapper, invocationInput, response);
-                                return;
-                            } else {
-                                GraphQLSingleInvocationInput invocationInput = invocationInputFactory.create(graphQLObjectMapper.readGraphQLRequest(inputStream), request);
-                                invocationInput.getContext().setFiles(fileItems);
-                                query(queryInvoker, graphQLObjectMapper, invocationInput, response);
-                                return;
-                            }
+                        final Optional<Part> queryItem = getFileItem(fileItems, key);
+                        if (!queryItem.isPresent()) {
+                            // If there is a part, but we don't see an item, then break and return BAD_REQUEST
+                            break;
                         }
-                    } else if (fileItems.containsKey("query")) {
-                        final Optional<Part> queryItem = getFileItem(fileItems, "query");
-                        if (queryItem.isPresent()) {
-                            InputStream inputStream = queryItem.get().getInputStream();
 
-                            if (!inputStream.markSupported()) {
-                                inputStream = new BufferedInputStream(inputStream);
-                            }
+                        InputStream inputStream = asMarkableInputStream(queryItem.get().getInputStream());
 
-                            if (isBatchedQuery(inputStream)) {
-                                GraphQLBatchedInvocationInput invocationInput = invocationInputFactory.create(graphQLObjectMapper.readBatchedGraphQLRequest(inputStream), request);
-                                invocationInput.getContext().setFiles(fileItems);
-                                queryBatched(queryInvoker, graphQLObjectMapper, invocationInput, response);
-                                return;
+                        final Optional<Map<String, List<String>>> variablesMap =
+                            getFileItem(fileItems, "map").map(graphQLObjectMapper::deserializeMultipartMap);
+
+                        if (isBatchedQuery(inputStream)) {
+                            List<GraphQLRequest> graphQLRequests =
+                                graphQLObjectMapper.readBatchedGraphQLRequest(inputStream);
+                            variablesMap.ifPresent(map -> graphQLRequests.forEach(r -> mapMultipartVariables(r, map, fileItems)));
+                            GraphQLBatchedInvocationInput invocationInput =
+                                invocationInputFactory.create(graphQLRequests, request);
+                            invocationInput.getContext().setFiles(fileItems);
+                            queryBatched(queryInvoker, graphQLObjectMapper, invocationInput, response);
+                            return;
+                        } else {
+                            GraphQLRequest graphQLRequest;
+                            if("query".equals(key)) {
+                                graphQLRequest = buildRequestFromQuery(inputStream, graphQLObjectMapper, fileItems);
                             } else {
-                                String query = new String(ByteStreams.toByteArray(inputStream));
-
-                                Map<String, Object> variables = null;
-                                final Optional<Part> variablesItem = getFileItem(fileItems, "variables");
-                                if (variablesItem.isPresent()) {
-                                    variables = graphQLObjectMapper.deserializeVariables(new String(ByteStreams.toByteArray(variablesItem.get().getInputStream())));
-                                }
-
-                                String operationName = null;
-                                final Optional<Part> operationNameItem = getFileItem(fileItems, "operationName");
-                                if (operationNameItem.isPresent()) {
-                                    operationName = new String(ByteStreams.toByteArray(operationNameItem.get().getInputStream())).trim();
-                                }
-
-                                GraphQLSingleInvocationInput invocationInput = invocationInputFactory.create(new GraphQLRequest(query, variables, operationName), request);
-                                invocationInput.getContext().setFiles(fileItems);
-                                query(queryInvoker, graphQLObjectMapper, invocationInput, response);
-                                return;
+                                graphQLRequest = graphQLObjectMapper.readGraphQLRequest(inputStream);
                             }
+
+                            variablesMap.ifPresent(m -> mapMultipartVariables(graphQLRequest, m, fileItems));
+                            GraphQLSingleInvocationInput invocationInput =
+                                invocationInputFactory.create(graphQLRequest, request);
+                            invocationInput.getContext().setFiles(fileItems);
+                            query(queryInvoker, graphQLObjectMapper, invocationInput, response);
+                            return;
                         }
                     }
 
                     response.setStatus(STATUS_BAD_REQUEST);
-                    log.info("Bad POST multipart request: no part named \"graphql\" or \"query\"");
+                    log.info("Bad POST multipart request: no part named " + Arrays.toString(MULTIPART_KEYS));
                 } else {
                     // this is not a multipart request
-                    InputStream inputStream = request.getInputStream();
-
-                    if (!inputStream.markSupported()) {
-                        inputStream = new BufferedInputStream(inputStream);
-                    }
+                    InputStream inputStream = asMarkableInputStream(request.getInputStream());
 
                     if (isBatchedQuery(inputStream)) {
                         queryBatched(queryInvoker, graphQLObjectMapper, invocationInputFactory.create(graphQLObjectMapper.readBatchedGraphQLRequest(inputStream), request), response);
@@ -229,6 +179,36 @@ public abstract class AbstractGraphQLHttpServlet extends HttpServlet implements 
                 response.setStatus(STATUS_BAD_REQUEST);
             }
         };
+    }
+
+    private static InputStream asMarkableInputStream(InputStream inputStream) {
+        if (!inputStream.markSupported()) {
+            inputStream = new BufferedInputStream(inputStream);
+        }
+        return inputStream;
+    }
+
+    private GraphQLRequest buildRequestFromQuery(InputStream inputStream,
+                                                 GraphQLObjectMapper graphQLObjectMapper,
+                                                 Map<String, List<Part>> fileItems) throws IOException
+    {
+        GraphQLRequest graphQLRequest;
+        String query = new String(ByteStreams.toByteArray(inputStream));
+
+        Map<String, Object> variables = null;
+        final Optional<Part> variablesItem = getFileItem(fileItems, "variables");
+        if (variablesItem.isPresent()) {
+            variables = graphQLObjectMapper.deserializeVariables(new String(ByteStreams.toByteArray(variablesItem.get().getInputStream())));
+        }
+
+        String operationName = null;
+        final Optional<Part> operationNameItem = getFileItem(fileItems, "operationName");
+        if (operationNameItem.isPresent()) {
+            operationName = new String(ByteStreams.toByteArray(operationNameItem.get().getInputStream())).trim();
+        }
+
+        graphQLRequest = new GraphQLRequest(query, variables, operationName);
+        return graphQLRequest;
     }
 
     private void mapMultipartVariables(GraphQLRequest request,

--- a/src/main/java/graphql/servlet/ApolloScalars.java
+++ b/src/main/java/graphql/servlet/ApolloScalars.java
@@ -1,0 +1,41 @@
+package graphql.servlet;
+
+import graphql.schema.Coercing;
+import graphql.schema.CoercingParseLiteralException;
+import graphql.schema.CoercingParseValueException;
+import graphql.schema.CoercingSerializeException;
+import graphql.schema.GraphQLScalarType;
+
+import javax.servlet.http.Part;
+
+public class ApolloScalars {
+    public static final GraphQLScalarType Upload =
+        new GraphQLScalarType("Upload",
+                              "A file part in a multipart request",
+                              new Coercing<Part, Void>() {
+                                  @Override
+                                  public Void serialize(Object dataFetcherResult) {
+                                      throw new CoercingSerializeException("Upload is an input-only type");
+                                  }
+
+                                  @Override
+                                  public Part parseValue(Object input) {
+                                      if (input instanceof Part) {
+                                          return (Part) input;
+                                      } else if (null == input) {
+                                          return null;
+                                      } else {
+                                          throw new CoercingParseValueException("Expected type " +
+                                                                                Part.class.getName() +
+                                                                                " but was " +
+                                                                                input.getClass().getName());
+                                      }
+                                  }
+
+                                  @Override
+                                  public Part parseLiteral(Object input) {
+                                      throw new CoercingParseLiteralException(
+                                          "Must use variables to specify Upload values");
+                                  }
+                              });
+}

--- a/src/main/java/graphql/servlet/GraphQLObjectMapper.java
+++ b/src/main/java/graphql/servlet/GraphQLObjectMapper.java
@@ -1,18 +1,17 @@
 package graphql.servlet;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.InjectableValues;
+import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.MappingIterator;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.ObjectReader;
-import com.fasterxml.jackson.databind.SerializationFeature;
-import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
 import graphql.ExecutionResult;
 import graphql.ExecutionResultImpl;
 import graphql.GraphQLError;
 import graphql.servlet.internal.GraphQLRequest;
 import graphql.servlet.internal.VariablesDeserializer;
 
+import javax.servlet.http.Part;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.ArrayList;
@@ -25,6 +24,9 @@ import java.util.function.Supplier;
  * @author Andrew Potter
  */
 public class GraphQLObjectMapper {
+    private static final TypeReference<Map<String, List<String>>>
+        MULTIPART_MAP_TYPE_REFERENCE = new TypeReference<Map<String, List<String>>>() {
+        };
     private final ObjectMapperProvider objectMapperProvider;
     private final Supplier<GraphQLErrorHandler> graphQLErrorHandlerSupplier;
 
@@ -142,6 +144,14 @@ public class GraphQLObjectMapper {
     public Map<String, Object> deserializeVariables(String variables) {
         try {
             return VariablesDeserializer.deserializeVariablesObject(getJacksonMapper().readValue(variables, Object.class), getJacksonMapper());
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    public Map<String,List<String>> deserializeMultipartMap(Part part) {
+        try {
+            return getJacksonMapper().readValue(part.getInputStream(), MULTIPART_MAP_TYPE_REFERENCE);
         } catch (IOException e) {
             throw new RuntimeException(e);
         }

--- a/src/main/java/graphql/servlet/internal/VariableMapper.java
+++ b/src/main/java/graphql/servlet/internal/VariableMapper.java
@@ -1,0 +1,76 @@
+package graphql.servlet.internal;
+
+import javax.servlet.http.Part;
+import java.util.List;
+import java.util.Map;
+import java.util.regex.Pattern;
+
+public class VariableMapper {
+    private static final Pattern PERIOD = Pattern.compile("\\.");
+
+    private static final Mapper<Map<String, Object>> MAP_MAPPER = new Mapper<Map<String, Object>>() {
+        @Override
+        public Object set(Map<String, Object> location, String target, Part value) {
+            return location.put(target, value);
+        }
+
+        @Override
+        public Object recurse(Map<String, Object> location, String target) {
+            return location.get(target);
+        }
+    };
+    private static final Mapper<List<Object>> LIST_MAPPER = new Mapper<List<Object>>() {
+        @Override
+        public Object set(List<Object> location, String target, Part value) {
+            return location.set(Integer.parseInt(target), value);
+        }
+
+        @Override
+        public Object recurse(List<Object> location, String target) {
+            return location.get(Integer.parseInt(target));
+        }
+    };
+
+    public static void mapVariable(String objectPath, Map<String, Object> variables, Part part) {
+        String[] segments = PERIOD.split(objectPath);
+
+        if (segments.length < 2) {
+            throw new RuntimeException("object-path in map must have at least two segments");
+        } else if (!"variables".equals(segments[0])) {
+            throw new RuntimeException("can only map into variables");
+        }
+
+        Object currentLocation = variables;
+        for (int i = 1; i < segments.length; i++) {
+            String segmentName = segments[i];
+            Mapper mapper = determineMapper(currentLocation, objectPath, segmentName);
+
+            if (i == segments.length - 1) {
+                if (null != mapper.set(currentLocation, segmentName, part)) {
+                    throw new RuntimeException("expected null value when mapping " + objectPath);
+                }
+            } else {
+                currentLocation = mapper.recurse(currentLocation, segmentName);
+                if (null == currentLocation) {
+                    throw new RuntimeException("found null intermediate value when trying to map " + objectPath);
+                }
+            }
+        }
+    }
+
+    private static Mapper<?> determineMapper(Object currentLocation, String objectPath, String segmentName) {
+        if (currentLocation instanceof Map) {
+            return MAP_MAPPER;
+        } else if (currentLocation instanceof List) {
+            return LIST_MAPPER;
+        }
+
+        throw new RuntimeException("expected a map or list at " + segmentName + " when trying to map " + objectPath);
+    }
+
+    interface Mapper<T> {
+        Object set(T location, String target, Part value);
+
+        Object recurse(T location, String target);
+    }
+}


### PR DESCRIPTION
This will allow the https://github.com/jaydenseric/graphql-multipart-request-spec
to be supported. [Apollo File Uploads](https://www.apollographql.com/docs/guides/file-uploads.html) are built on top of this.